### PR TITLE
src/pv/number.c: add missing <stddef.h> include for NULL

### DIFF
--- a/src/pv/number.c
+++ b/src/pv/number.c
@@ -2,6 +2,8 @@
  * Functions for converting strings to numbers.
  */
 
+#include <stddef.h>
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif


### PR DESCRIPTION
Fixes a build failure like this:
```
x86_64-pc-linux-gnu-gcc -O2 -pipe -march=native -fdiagnostics-color=always -frecord-gcc-switches -I./src/include -Isrc/include -DHAVE_CONFIG_H -DLOCALEDIR=\"/usr/share/locale\" -c -o src/pv/number.o src/pv/number.c
x86_64-pc-linux-gnu-gcc -O2 -pipe -march=native -fdiagnostics-color=always -frecord-gcc-switches -I./src/include -Isrc/include -DHAVE_CONFIG_H -DLOCALEDIR=\"/usr/share/locale\" -c -o src/pv/signal.o src/pv/signal.c
x86_64-pc-linux-gnu-gcc -O2 -pipe -march=native -fdiagnostics-color=always -frecord-gcc-switches -I./src/include -Isrc/include -DHAVE_CONFIG_H -DLOCALEDIR=\"/usr/share/locale\" -c -o src/pv/state.o src/pv/state.c
src/pv/number.c: In function ‘pv_getnum_ull’:
src/pv/number.c:32:13: error: ‘NULL’ undeclared (first use in this function)
   32 |         if (NULL == str)
      |             ^~~~
src/pv/number.c:9:1: note: ‘NULL’ is defined in header ‘<stddef.h>’; did you forget to ‘#include <stddef.h>’?
    8 | #include "pv.h"
  +++ |+#include <stddef.h>
    9 |
src/pv/number.c:32:13: note: each undeclared identifier is reported only once for each function it appears in
   32 |         if (NULL == str)
      |             ^~~~
src/pv/number.c: In function ‘pv_getnum_d’:
src/pv/number.c:122:13: error: ‘NULL’ undeclared (first use in this function)
  122 |         if (NULL == str)
      |             ^~~~
src/pv/number.c:122:13: note: ‘NULL’ is defined in header ‘<stddef.h>’; did you forget to ‘#include <stddef.h>’?
make: *** [Makefile:362: src/pv/number.o] Error 1
make: *** Waiting for unfinished jobs....
src/pv/loop.c: In function ‘pv_main_loop’:
```

Thanks!