### PR TITLE
Add -s @FILENAME for specifying size

### DIFF
--- a/autoconf/configure.in
+++ b/autoconf/configure.in
@@ -156,7 +156,12 @@ dnl
 AC_DEFINE(HAVE_CONFIG_H)
 AC_HEADER_STDC
 AC_HEADER_STDBOOL
-AC_CHECK_FUNCS(memcpy basename snprintf stat64)
+AC_CHECK_FUNCS(memcpy basename snprintf)
+dnl OSX 11 (apple silicon) lets you link stat64() but fails to compile
+dnl so use a compile test for stat64() instead of a link test.
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() { stat64(); }])],
+		  [AC_DEFINE([HAVE_STAT64], [1], [Is stat64() available])],
+		  [])
 AC_CHECK_HEADERS(limits.h)
 
 if test "$IPC_SUPPORT" = "yes"; then

--- a/doc/quickref.1.in
+++ b/doc/quickref.1.in
@@ -242,6 +242,9 @@ bytes when calculating percentages and ETAs.  The same suffixes of "k", "m"
 etc can be used as with
 .BR -L .
 .TP
+If you start the SIZE with the letter "@", the rest should be a
+filename to stat(2) to read the file size.
+.TP
 .B ""
 Has no effect if used with
 .B -d PID


### PR DESCRIPTION
Intended to address Issue #44 to allow `pv -s @filename` like curl(1).

Also fixes compilation on latest OSX on Apple Silicon where stat64() and friends are linkable but not compilable.