### PR TITLE
fix rate limiting issues

### DIFF
--- a/src/include/pv-internal.h
+++ b/src/include/pv-internal.h
@@ -34,6 +34,7 @@ extern "C" {
 #define PV_DISPLAY_FINETA	512
 
 #define RATE_GRANULARITY	100000	 /* usec between -L rate chunks */
+#define RATE_BURST_WINDOW	5	 /* rate burst window (multiples of rate) */
 #define REMOTE_INTERVAL		100000	 /* usec between checks for -R */
 #define BUFFER_SIZE		409600	 /* default transfer buffer size */
 #define BUFFER_SIZE_MAX		524288	 /* max auto transfer buffer size */

--- a/src/pv/loop.c
+++ b/src/pv/loop.c
@@ -151,10 +151,15 @@ int pv_main_loop(pvstate_t state)
 			    || (cur_time.tv_sec == next_ratecheck.tv_sec
 				&& cur_time.tv_usec >=
 				next_ratecheck.tv_usec)) {
+
 				target +=
 				    ((long double) (state->rate_limit)) /
 				    (long double) (1000000 /
 						   RATE_GRANULARITY);
+				long double burstMax = ((long double) (state->rate_limit * RATE_BURST_WINDOW));
+				if (target > burstMax) {
+					target = burstMax;
+				}
 				pv_timeval_add_usec(&next_ratecheck,
 						    RATE_GRANULARITY);
 			}


### PR DESCRIPTION
Current implementation of rate limiting is similar to [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm, however it doesn't limit capacity of "bucket", so it when transfer rate is below rate limit it allows to grows "bucket" indefinitely. 
Applying limit fixes this issue.
(also this problem described in issue https://github.com/a-j-wood/pv/issues/32)