### PR TITLE
Add -8/--bits option to display bits, not bytes

### DIFF
--- a/doc/ACKNOWLEDGEMENTS.md
+++ b/doc/ACKNOWLEDGEMENTS.md
@@ -72,5 +72,6 @@ is acknowledged and greatly appreciated:
  * Johannes Gerer <http://johannesgerer.com> - suggested that "-B" should enable "-C"
  * Sam James - provided fix for number.c build issue caused by missing stddef.h
  * Jakub Wilk <jwilk@jwilk.net> - corrected README encoding
+ * nick black <https://nick-black.com> - added "--bits" option
 
 ---

--- a/doc/quickref.1.in
+++ b/doc/quickref.1.in
@@ -145,6 +145,11 @@ transfer.
 Turn the average rate counter on.  This will display the average rate of
 data transfer so far.
 .TP
+.TP
+.B \-8, \-\-bits
+Display bits instead of bytes. Output will use a lowercase 'b' in place
+of the usual uppercase 'B'.
+.TP
 .B \-b, \-\-bytes
 Turn the total byte counter on.  This will display the total amount of
 data transferred so far.

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -21,6 +21,7 @@ struct opts_s {           /* structure describing run-time options */
 	bool fineta;                   /* absolute ETA flag */
 	bool rate;                     /* rate counter flag */
 	bool average_rate;             /* average rate counter flag */
+	bool bits;                     /* display bits flag */
 	bool bytes;                    /* bytes transferred flag */
 	bool bufpercent;               /* transfer buffer percentage flag */
 	unsigned int lastwritten;      /* show N bytes last written */

--- a/src/include/pv-internal.h
+++ b/src/include/pv-internal.h
@@ -65,6 +65,7 @@ struct pvstate_s {
 	bool linemode;                   /* count lines instead of bytes */
 	bool null;                       /* lines are null-terminated */
 	bool no_op;                      /* do nothing other than pipe data */
+	bool bits;                       /* display bits, not bytes */
 	unsigned int skip_errors;        /* skip read errors counter */
 	bool stop_at_size;               /* set if we stop at "size" bytes */
 	bool no_splice;                  /* never use splice() */

--- a/src/include/pv.h
+++ b/src/include/pv.h
@@ -93,6 +93,7 @@ extern void pv_state_name_set(pvstate_t, const char *);
 extern void pv_state_format_string_set(pvstate_t, const char *);
 extern void pv_state_watch_pid_set(pvstate_t, unsigned int);
 extern void pv_state_watch_fd_set(pvstate_t, int);
+extern void pv_state_bits_set(pvstate_t, bool);
 
 extern void pv_state_inputfiles(pvstate_t, int, const char **);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -206,6 +206,7 @@ int main(int argc, char **argv)
 	pv_state_format_string_set(state, opts->format);
 	pv_state_watch_pid_set(state, opts->watch_pid);
 	pv_state_watch_fd_set(state, opts->watch_fd);
+	pv_state_bits_set(state, opts->bits);
 
 	pv_state_set_format(state, opts->progress, opts->timer, opts->eta,
 			    opts->fineta, opts->rate, opts->average_rate,

--- a/src/main/options.c
+++ b/src/main/options.c
@@ -55,6 +55,7 @@ opts_t opts_parse(int argc, char **argv)
 		{"fineta", 0, NULL, (int) 'I'},
 		{"rate", 0, NULL, (int) 'r'},
 		{"average-rate", 0, NULL, (int) 'a'},
+		{"bits", 0, NULL, (int) '8'},
 		{"bytes", 0, NULL, (int) 'b'},
 		{"buffer-percent", 0, NULL, (int) 'T'},
 		{"last-written", 1, NULL, (int) 'A'},
@@ -85,7 +86,7 @@ opts_t opts_parse(int argc, char **argv)
 	int option_index = 0;
 #endif
 	char *short_options =
-	    "hVpteIrabTA:fnqcWD:s:l0i:w:H:N:F:L:B:CESR:P:d:";
+	    "hVpteIra8bTA:fnqcWD:s:l0i:w:H:N:F:L:B:CESR:P:d:";
 	int c, numopts;
 	unsigned int check_pid;
 	int check_fd;
@@ -222,6 +223,9 @@ opts_t opts_parse(int argc, char **argv)
 			opts->average_rate = true;
 			numopts++;
 			break;
+		case '8':
+			opts->bits = true;
+			numopts++;
 		case 'b':
 			opts->bytes = true;
 			numopts++;

--- a/src/pv/display.c
+++ b/src/pv/display.c
@@ -193,14 +193,14 @@ static void pv__si_prefix(long double *value, char *prefix,
  * parameter (a %s) which will expand to the string described above.
  */
 static void pv__sizestr(char *buffer, int bufsize, char *format,
-			long double amount, char *suffix_basic,
-			char *suffix_bytes, int is_bytes)
+			long double amount, const char *suffix_basic,
+			const char *suffix_bytes, int is_bytes)
 {
 	char sizestr_buffer[256];
 	char si_prefix[8] = " ";
 	long double divider;
 	long double display_amount;
-	char *suffix;
+	const char *suffix;
 
 	if (is_bytes) {
 		suffix = suffix_bytes;
@@ -613,9 +613,17 @@ static char *pv__format(pvstate_t state,
 
 	/* If we're showing bytes transferred, set up the display string. */
 	if ((state->components_used & PV_DISPLAY_BYTES) != 0) {
+		const char* suffix;
+		long double total = total_bytes;
+		if (state->bits) {
+			suffix = _("b");
+			total *= 8;
+		}else{
+			suffix = _("B");
+		}
 		pv__sizestr(state->str_transferred,
 			    sizeof(state->str_transferred), "%s",
-			    (long double) total_bytes, "", _("B"),
+			    total, "", suffix,
 			    state->linemode ? 0 : 1);
 	}
 

--- a/src/pv/state.c
+++ b/src/pv/state.c
@@ -211,6 +211,12 @@ void pv_state_watch_fd_set(pvstate_t state, int val)
 	state->watch_fd = val;
 };
 
+void pv_state_bits_set(pvstate_t state, bool bits)
+{
+	state->bits = bits;
+};
+
+
 
 /*
  * Set the array of input files.


### PR DESCRIPTION
When measuring networking performance, we typically use bits rather than bytes. Add an option, `-8`/`--bits`, which when used outputs in bits (and uses a 'b' suffix). The `-b` short option was already in use, hence the `-8`.

I think I still need generate a gettext entry for `_("b")`. I'm looking into it.