### PR TITLE
pv/display: handle error of tcgetpgrp() in pv_in_foreground()

### DIFF
--- a/src/pv/display.c
+++ b/src/pv/display.c
@@ -48,6 +48,10 @@ bool pv_in_foreground(void)
 
 	our_process_group = getpgrp();
 	tty_process_group = tcgetpgrp(STDERR_FILENO);
+
+	if (tty_process_group == -1 && errno == ENOTTY)
+		return true;
+
 	if (our_process_group == tty_process_group)
 		return true;
 


### PR DESCRIPTION
Show pv progress bar even if no terminal is set, e.g., in a busybox init script. The description of pv_in_forground() states it will return true "if we aren't outputting to a terminal". However, this is not the case since tcgetpgrg() will return an error and set ERRNO to ENOTTY if the output fd is not an tty. We now handle this error correctly and pv_in_foreground() returns also true in that case.

We use pv in the busybox initscript of GyroidOS which is running on /dev/console (which has no controlling tty). With this
fix, we get the progress bar back on /dev/console as before with 1.6.6. So this should also fix
"No output in Arch Linux initcpio after 1.6.6 #19" and also relates to "pv Stopped Working in the Background #55"