### PR TITLE
Use relative filepath in watchpid if possible

### DIFF
--- a/src/include/pv-internal.h
+++ b/src/include/pv-internal.h
@@ -85,6 +85,7 @@ struct pvstate_s {
 	 * Program status *
 	 ******************/
 	const char *program_name;	 /* program name for error reporting */
+	char cwd[4096];			 /* current working directory for relative path */
 	const char *current_file;	 /* current file being read */
 	int exit_status; 		 /* exit status to give (0=OK) */
 

--- a/src/pv/state.c
+++ b/src/pv/state.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 
 /*
@@ -35,6 +36,16 @@ pvstate_t pv_state_alloc(const char *program_name)
 	state->splice_failed_fd = -1;
 #endif				/* HAVE_SPLICE */
 	state->display_visible = false;
+
+	//get cwd from system and set to state
+	if (NULL == getcwd(state->cwd, sizeof(state->cwd))) {
+		// ignore error, using full path
+		state->cwd[0] = '\0';
+	}
+	if ('\0' == state->cwd[1]) {
+		// ignore when current working directory is root directory
+		state->cwd[0] = '\0';
+	}
 
 	return state;
 }


### PR DESCRIPTION
Hi, I propose the following feature.

Currently, when using pv with watchpid (`-d` option), it always displays the absolute file path. Fix this to only show a relative path if the file is in a subpath of the current working directory (CWD).

I couldn't name an option to turn this feature on and off, so I implemented it to be on by default. If needed, I'd be happy to hear suggestions for an option character to set whether this feature is enabled or disabled.